### PR TITLE
CI: Appveyor build for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TouHou Player
 
+[![Build status](https://ci.appveyor.com/api/projects/status/3hnd8quh22grg4gv/branch/master?svg=true)](https://ci.appveyor.com/project/BLumia/thplayer/branch/master)
+
 [Website](https://bearkidsteam.github.io/thplayer/)
 
 TouHou BGM player for all platform.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ build_script:
   - cd build
   - qmake ..\thplayer.pro
   - mingw32-make
+  - tree
+  - cd release
   - dir
-  - cd
-  - windeployqt --no-quick-import .\thplayer.exe
+  - windeployqt --no-quick-import  --release .\thplayer.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+    - build_name: mingw53_32_qt5_11_2
+      QTPATH: C:\Qt\5.11.2\mingw53_32
+      MINGW32: C:\Qt\Tools\mingw530_32
+#    - build_name: msvc2017_64
+#      QTPATH: C:\Qt\5.11.2\msvc2017_64
+#      MINGW32: C:\Qt\Tools\mingw530_32
+
+install:
+  - set PATH=%PATH%;%QTDIR%\bin;%MINGW32%\bin
+
+build_script:
+  - mkdir build
+  - cd build
+  - qmake ..\thplayer.pro
+  - mingw32-make
+  - windeployqt --no-quick-import .\thplayer.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ environment:
 #      MINGW32: C:\Qt\Tools\mingw530_32
 
 install:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - git submodule update --init --recursive
   - set PATH=%PATH%;%QTPATH%\bin;%MINGW32%\bin
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 #      MINGW32: C:\Qt\Tools\mingw530_32
 
 install:
-  - set PATH=%PATH%;%QTDIR%\bin;%MINGW32%\bin
+  - set PATH=%PATH%;%QTPATH%\bin;%MINGW32%\bin
 
 build_script:
   - mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,4 +21,4 @@ build_script:
   - windeployqt --no-quick-import  --release .\thplayer.exe
 
 artifacts:
-  - path: %APPVEYOR_BUILD_FOLDER%\build\release
+  - path: build\release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,8 @@ build_script:
   - cd build
   - qmake ..\thplayer.pro
   - mingw32-make
-  - tree
   - cd release
-  - dir
   - windeployqt --no-quick-import  --release .\thplayer.exe
+
+artifacts:
+  - path: %APPVEYOR_BUILD_FOLDER%\build\release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,4 +17,6 @@ build_script:
   - cd build
   - qmake ..\thplayer.pro
   - mingw32-make
+  - dir
+  - cd
   - windeployqt --no-quick-import .\thplayer.exe


### PR DESCRIPTION
Add Appveyor build for windows. Test build artifacts can be downloaded at [here](https://ci.appveyor.com/project/BLumia/thplayer/build/artifacts).